### PR TITLE
solves partially ticket 5405

### DIFF
--- a/R/validateData.R
+++ b/R/validateData.R
@@ -53,14 +53,11 @@ if (Sys.info()[['sysname']] == "Windows"  ) {
                                     .parallel=parallel,
                                     .inform=TRUE)
     }
-    
-if ( nrow(validation.results) > 0 ) {
-validation.results$orgUnit<-remapOUs(validation.results$orgUnit,
-                                     organisationUnit,
-                                     mode_in="id",mode_out="code")
-validation.results$attributeOptionCombo<-remapMechs(validation.results$attributeOptionCombo,
-                                                    organisationUnit,
-                                                    mode_in="id",mode_out="code") }
+ 
+#if ( nrow(validation.results) > 0 ) {
+#validation.results$orgUnit<-remapOUs(validation.results$orgUnit,  organisationUnit,  mode_in="id",mode_out="code")
+#validation.results$attributeOptionCombo<-remapMechs(validation.results$attributeOptionCombo,  organisationUnit,  mode_in="id",mode_out="code") 
+#}
 
 validation.results<-plyr::colwise(as.character)(validation.results) 
   


### PR DESCRIPTION
Since  data frame 'validation.results' doesn't have columns validation.results$orgUnit and validation.results$attributeOptionCombo, it probably isn't necessary calling remapOUs and remapMechs. Alternatively the columns attributeOptionCombo and orgUnit can be added to validation.results_empty but then this adds empty attributeOptionCombo and orgUnit columns to the validation violations csv file. 
