### PR TITLE
Fix of data element cadence validation function

### DIFF
--- a/R/checkDataElementCadence.R
+++ b/R/checkDataElementCadence.R
@@ -22,7 +22,7 @@ checkDataElementCadence<-function(data,d2session = d2_default_session){
   
   #Get a listing of periods which are present in the data
   des_periods<-unique(data[,c("period","dataElement")])
-  cadence_maps<-purrr::map_dfr(unique(des_periods$period),getDataElementCadenceMapForPeriod(.,d2session = d2session)) %>% 
+  cadence_maps<-purrr::map_dfr(unique(des_periods$period),~getDataElementCadenceMapForPeriod(.,d2session = d2session)) %>% 
     dplyr::select(period,dataElement=uid)
   
   data_des_periods_bad<-dplyr::anti_join(des_periods,cadence_maps,by=c("period","dataElement"))
@@ -43,7 +43,7 @@ getDataElementCadenceMapForPeriod <- function(period,d2session = d2_default_sess
   url <-
     URLencode(
       paste0(
-        d2session$baseurl,
+        d2session$base_url,
         "api/",
         api_version(),
         "/dataStore/dataElementCadence/",
@@ -56,15 +56,15 @@ getDataElementCadenceMapForPeriod <- function(period,d2session = d2_default_sess
     r <- httr::GET(url , httr::timeout(300), handle = d2session$handle)
     if (r$status == 200L) {
       r <- httr::content(r, "text")
-      cadence_map <- jsonlite::fromJSON(r)
-      cadence_map_df<-cadence_map$dataElements
-      cadence_map_df$period<-cadence_map$period
-      saveCachedObject(cadence_map_df, sig)
+      cadence_map_json <- jsonlite::fromJSON(r)
+      cadence_map<-cadence_map_json$dataElements
+      cadence_map$period<-cadence_map_json$period
+      saveCachedObject(cadence_map, sig)
     } else {
       stop("Could not retreive data element cadence map for period ",
            period)
     }
   }
-  return(cadence_map_df)
+  return(cadence_map)
 }
   

--- a/R/checkDataElementOrgunitValidity.R
+++ b/R/checkDataElementOrgunitValidity.R
@@ -97,7 +97,7 @@ getDataElementsOrgunits <- function(
 #'      checkDataElementOrgunitValidity(data=d,datasets=ds)
 #' }
 
-checkDataElementOrgunitValidity<-function(data=NA,organisationUnit=NA,datasets=NA,return_violations=TRUE, d2session) {
+checkDataElementOrgunitValidity<-function(data=NA,organisationUnit=NA,datasets=NA,return_violations=TRUE, d2session = d2_default_session) {
   
   if (is.na(organisationUnit)) { organisationUnit = d2session$user_orgunit}
   if ( NROW(data) == 0  ) {stop("Data cannot be missing!")}


### PR DESCRIPTION
checkDataElementCadence.R has several bugs. This PR is addressing those, plus making checkDataElementOrgunitValidity.R exported function signature be consistent with the others, by making d2session default to d2_default_session variable.

checkDataElementCadence issues being addressed are:
- made getDataElementCadenceMapForPeriod be evaluated as formula, otherwise it would choke on . argument;
- fixed base url variable name (from baseurl to base_url) to be consistent with the d2session variable name;
- updated caching related variable names. Before the fix, json content, instead of the data frame was being stored in cache, causing any subsequent run to choke unless cache was cleared.