### PR TITLE
Load rules + Evaluation fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datimvalidation
 Type: Package
 Title: External Validation Routines for Data Payloads in DATIM
-Version: 1.0.116
+Version: 1.0.117
 Date: 2021-03-22
 Author: Jason P. Pickering
 Maintainer: Jason P. Pickering <jason.p.pickering@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datimvalidation
 Type: Package
 Title: External Validation Routines for Data Payloads in DATIM
-Version: 1.0.117
+Version: 1.0.118
 Date: 2021-03-22
 Author: Jason P. Pickering
 Maintainer: Jason P. Pickering <jason.p.pickering@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datimvalidation
 Type: Package
 Title: External Validation Routines for Data Payloads in DATIM
-Version: 1.0.115
+Version: 1.0.116
 Date: 2021-03-22
 Author: Jason P. Pickering
 Maintainer: Jason P. Pickering <jason.p.pickering@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datimvalidation
 Type: Package
 Title: External Validation Routines for Data Payloads in DATIM
-Version: 1.0.114
-Date: 2021-03-09
+Version: 1.0.115
+Date: 2021-03-22
 Author: Jason P. Pickering
 Maintainer: Jason P. Pickering <jason.p.pickering@gmail.com>
 Description: A comprehensive set of tools to validate data payloads

--- a/R/evaluateValidation.R
+++ b/R/evaluateValidation.R
@@ -82,27 +82,17 @@ evaluateValidation<-function(combis,values,vr,return_violations_only=TRUE) {
   
 
   #Keep rules which should  be evaluated
-  keep_these_rules <-
-    (
-      matches$leftSide.missingValueStrategy == "SKIP_IF_ANY_VALUE_MISSING" &
-        (matches$leftSide.ops != matches$leftSide.count)
-    ) |
-    (
-      matches$rightSide.missingValueStrategy == "SKIP_IF_ANY_VALUE_MISSING" &
-        (matches$rightSide.ops != matches$rightSide.count)
-    ) |
-    (matches$rightSide.missingValueStrategy == "NEVER_SKIP") |
-    (matches$leftSide.missingValueStrategy == "NEVER_SKIP") |
-    (
-      (matches$rightSide.count == matches$rightSide.ops)  &
+    keep_these_rules <- (
+      (
+        matches$leftSide.missingValueStrategy == "NEVER_SKIP" |
+          (matches$leftSide.missingValueStrategy == "SKIP_IF_ANY_VALUE_MISSING" & matches$leftSide.ops != matches$leftSide.count) |
+          (matches$leftSide.missingValueStrategy == "SKIP_IF_ALL_VALUES_MISSING" & matches$leftSide.count != 0)
+      )
+      &
         (
-          matches$rightSide.missingValueStrategy == "SKIP_IF_ALL_VALUES_MISSING"
-        )
-    ) |
-    (
-      (matches$leftSide.count == matches$leftSide.ops)  &
-        (
-          matches$leftSide.missingValueStrategy == "SKIP_IF_ALL_VALUES_MISSING"
+          matches$rightSide.missingValueStrategy == "NEVER_SKIP" |
+            (matches$rightSide.missingValueStrategy == "SKIP_IF_ANY_VALUE_MISSING" & matches$rightSide.ops != matches$rightSide.count) |
+            (matches$rightSide.missingValueStrategy == "SKIP_IF_ALL_VALUES_MISSING" & matches$rightSide.count != 0)
         )
     )
   

--- a/R/validateData.R
+++ b/R/validateData.R
@@ -63,11 +63,12 @@ prepDataForValidation <- function(d) {
 #' @description validateData should be supplied a d2Parser compliant data frame.
 #'The data frame is checked dynamically against validation rules defined in the DATIM server.
 #' @param data d2Parser data frame
-#' @param organisationUnit Organisation unit. Defaults to the user organisation unit if not supplied.
-#' @param return_violations_only Paramater to return only violations or all validation rule evalualtions.
+#' @param organisationUnit Organization unit. Defaults to the user organization unit if not supplied.
+#' @param return_violations_only Parameter to return only violations or all validation rule evaluations.
 #' @param parallel Should the rules be evaluated in parallel. Default is to not evaluate in parallel.
 #' @param datasets Vector of dataset UIDs which can  be used to restrict
 #' the validation rules which will be applied.
+#' @param vr Data frame of validation rules from getValidationRules, or a custom filtered data frame. 
 #' @param d2session datimutils d2session object
 #' @return Returns a data frame with validation rule results.
 #' @examples \dontrun{
@@ -83,7 +84,7 @@ validateData <-function(data,
            return_violations_only = TRUE,
            parallel = FALSE,
            datasets = NA, 
-           validation_rules = NULL,
+           vr = NULL,
            d2session = d2_default_session) {
     
   if (nrow(data) == 0 ||

--- a/R/validateData.R
+++ b/R/validateData.R
@@ -82,7 +82,9 @@ validateData <-function(data,
            organisationUnit = NA,
            return_violations_only = TRUE,
            parallel = FALSE,
-           datasets = NA, d2session = d2_default_session) {
+           datasets = NA, 
+           validation_rules = NULL,
+           d2session = d2_default_session) {
     
   if (nrow(data) == 0 ||
       is.null(data)) {
@@ -130,8 +132,11 @@ validation.results_empty <- data.frame(
 )
 validation.results <- validation.results_empty
 
-#Check the data against the validation rules
-vr <- getValidationRules(d2session = d2session)
+#Load validation rules from the server if none are supplied.
+if (is.null(vr)) {
+  vr <- getValidationRules(d2session = d2session)
+}
+
 if (Sys.info()[['sysname']] == "Windows") {
   if (parallel == TRUE)  {
     warning("Parallel execution is not supported on Windows")

--- a/man/checkDataElementOrgunitValidity.Rd
+++ b/man/checkDataElementOrgunitValidity.Rd
@@ -9,7 +9,7 @@ checkDataElementOrgunitValidity(
   organisationUnit = NA,
   datasets = NA,
   return_violations = TRUE,
-  d2session
+  d2session = d2_default_session
 )
 }
 \arguments{

--- a/man/validateData.Rd
+++ b/man/validateData.Rd
@@ -10,20 +10,23 @@ validateData(
   return_violations_only = TRUE,
   parallel = FALSE,
   datasets = NA,
+  vr = NULL,
   d2session = d2_default_session
 )
 }
 \arguments{
 \item{data}{d2Parser data frame}
 
-\item{organisationUnit}{Organisation unit. Defaults to the user organisation unit if not supplied.}
+\item{organisationUnit}{Organization unit. Defaults to the user organization unit if not supplied.}
 
-\item{return_violations_only}{Paramater to return only violations or all validation rule evalualtions.}
+\item{return_violations_only}{Parameter to return only violations or all validation rule evaluations.}
 
 \item{parallel}{Should the rules be evaluated in parallel. Default is to not evaluate in parallel.}
 
 \item{datasets}{Vector of dataset UIDs which can  be used to restrict
 the validation rules which will be applied.}
+
+\item{vr}{Data frame of validation rules from getValidationRules, or a custom filtered data frame.}
 
 \item{d2session}{datimutils d2session object}
 }


### PR DESCRIPTION
1) Add a feature to allow the loading of a custom data frame of validation rules. Useful, if you do not want to retrieve the ones which are actually on the server. 
2) Fix a bug in how missing value strategies are handled. 